### PR TITLE
Update web.config to store username/tenant config

### DIFF
--- a/APIStarterKit/App_Start/IzendaConfig.cs
+++ b/APIStarterKit/App_Start/IzendaConfig.cs
@@ -2,6 +2,7 @@
 using Izenda.BI.Logic.CustomConfiguration;
 using System;
 using System.Collections.Generic;
+using System.Configuration;
 using System.Linq;
 using System.Web;
 
@@ -19,8 +20,8 @@ namespace APIStarterKit.App_Start
                  */
                 return new ValidateTokenResult
                 {
-                    UserName = "IzendaAdmin",
-                    TenantUniqueName = ""
+                    UserName = ConfigurationManager.AppSettings["IzendaUsername"],
+                    TenantUniqueName = ConfigurationManager.AppSettings["IzendaTenantUniqueName"]
                 };
             };
         }

--- a/APIStarterKit/Web.config
+++ b/APIStarterKit/Web.config
@@ -86,6 +86,8 @@
     <add key="IzendaApiUrl" value="http://localhost:63679/api/" />
     <add key="izusername" value="IzendaAdmin@system.com" />
     <add key="iztenantname" value="" />
+    <add key="izendausername" value="IzendaAdmin"/>
+    <add key="izendatenantuniquename" value=""/>
     <!--Izenda End-->
 
   </appSettings>


### PR DESCRIPTION
To make it easier to switch between the admin user and a tenant user, store the username and tenant in the web.config file and reference them from there.  This has the advantage that we don't need to compile the app to change the user.